### PR TITLE
Add parallel dependency check in perm_test.cross_projector

### DIFF
--- a/R/twoway_projector.R
+++ b/R/twoway_projector.R
@@ -504,8 +504,10 @@ perm_test.cross_projector <- function(x,
   }
   
   # ---------- Run Permutations (Serial or Parallel) ----------
-  message(sprintf("Running %d permutations for cross projector (%s)...", 
+  message(sprintf("Running %d permutations for cross projector (%s)...",
                   nperm, if(parallel) "parallel" else "serial"))
+  if (parallel && !requireNamespace("future.apply", quietly = TRUE))
+    stop("Package 'future.apply' required for parallel execution.", call.=FALSE)
   apply_fun <- if (parallel) future.apply::future_lapply else lapply
   perm_args <- list(X = seq_len(nperm), FUN = one_perm)
   # Pass ... down to one_perm via the lapply function's ...

--- a/man/perm_test.Rd
+++ b/man/perm_test.Rd
@@ -31,7 +31,7 @@ perm_test(x, ...)
 
 \item{stepwise}{(Used by \code{pca}) Logical indicating if sequential testing (P3 projection) should be performed. Default \code{TRUE}. (The multiblock methods also perform sequential testing based on \code{alpha} and \code{comps}, but this argument is ignored). Ignored by other methods.}
 
-\item{parallel}{(Used by all methods) Logical; if \code{TRUE}, attempt parallel execution via \code{future.apply::future_lapply}.}
+\item{parallel}{(Used by all methods) Logical; if \code{TRUE}, attempt parallel execution via \code{future.apply::future_lapply}. Requires the \code{future.apply} package.}
 
 \item{alternative}{(Used by all methods) Character string for the alternative hypothesis: "greater" (default), "less", or "two.sided".}
 


### PR DESCRIPTION
## Summary
- ensure `perm_test.cross_projector` stops when `future.apply` is missing for parallel runs
- document the `future.apply` requirement in `perm_test` documentation

## Testing
- `R -q -e "devtools::test()"` *(fails: `R` command not found)*