### PR TITLE
Fix reconstruct_new.bi_projector preprocessing

### DIFF
--- a/R/bi_projector.R
+++ b/R/bi_projector.R
@@ -164,12 +164,10 @@ reconstruct_new.bi_projector <- function(x,
   chk::chk_equal(ncol(new_data), length(colind))
   
   # Use standard project method for consistency
-  # First, apply preprocessing only to the specified columns
-  full_data <- matrix(0, nrow = nrow(new_data), ncol = nrow(coef.projector(x)))
-  full_data[, colind] <- new_data
-  
-  # Apply preprocessing to full data
-  full_data_proc <- apply_transform(x$preproc, full_data)
+  # Apply preprocessing only to the provided columns
+  full_data_proc <- matrix(0, nrow = nrow(new_data),
+                           ncol = nrow(coef.projector(x)))
+  full_data_proc[, colind] <- apply_transform(x$preproc, new_data, colind)
   
   # Project to get scores for all components
   scores_new_full <- project(x, full_data_proc)
@@ -184,7 +182,8 @@ reconstruct_new.bi_projector <- function(x,
   
   # Reconstruct
   rec_data_sub <- scores_new %*% ip_sub
-  
+
   # Reverse transform for the selected columns
+  rec_data_sub <- reverse_transform(x$preproc, rec_data_sub, colind)
   rec_data_sub
 }

--- a/tests/testthat/test_reconstruct_new_biprojector.R
+++ b/tests/testthat/test_reconstruct_new_biprojector.R
@@ -1,0 +1,23 @@
+context("reconstruct_new.bi_projector")
+
+library(testthat)
+library(multivarious)
+
+set.seed(123)
+
+X <- matrix(rnorm(20 * 6), 20, 6)
+fit <- pca(X, preproc = standardize())
+
+# full reconstruction via reconstruct_new on all columns
+full_rec <- reconstruct_new(fit, X, comp = 1:ncomp(fit))
+
+# partial reconstruction using only subset of columns
+cols <- 1:3
+partial_rec <- reconstruct_new(fit, X[, cols], colind = cols, comp = 1:ncomp(fit))
+
+# the partial reconstruction should match the corresponding subset
+# of the full reconstruction
+
+test_that("partial reconstruction matches subset of full reconstruction", {
+  expect_equal(partial_rec, full_rec[, cols], tolerance = 1e-6, ignore_attr = TRUE)
+})


### PR DESCRIPTION
## Summary
- preprocess columns using `apply_transform` instead of zero-filled matrix
- apply `reverse_transform` when reconstructing new data
- add test verifying partial reconstruction

## Testing
- `R -q -e 'devtools::test()'` *(fails: `bash: R: command not found`)*