### PR TITLE
Ensure X and Y blocks have same components

### DIFF
--- a/R/twoway_projector.R
+++ b/R/twoway_projector.R
@@ -7,8 +7,8 @@
 #' and `coef` work, but by default, it is assumed that the `X` block is primary. To access `Y` block operations, an
 #' additional argument `source` must be supplied to the relevant functions, e.g., `coef(fit, source = "Y")`
 #'
-#' @param vx the X coefficients
-#' @param vy the Y coefficients
+#' @param vx the X coefficients. Must have the same number of columns as `vy`.
+#' @param vy the Y coefficients. Must have the same number of columns as `vx`.
 #' @param preproc_x the X pre-processor
 #' @param preproc_y the Y pre-processor
 #' @param ... extra parameters or results to store
@@ -33,6 +33,7 @@ cross_projector <- function(vx, vy, preproc_x=prep(pass()), preproc_y=prep(pass(
   
   chk::chkor_vld(chk::vld_matrix(vx), chk::vld_s4_class(vx, "Matrix"))
   chk::chkor_vld(chk::vld_matrix(vy), chk::vld_s4_class(vy, "Matrix"))
+  chk::chk_equal(ncol(vx), ncol(vy))
   chk::chk_s3_class(preproc_x, "pre_processor")
   chk::chk_s3_class(preproc_y, "pre_processor")
   

--- a/man/cross_projector.Rd
+++ b/man/cross_projector.Rd
@@ -14,9 +14,9 @@ cross_projector(
 )
 }
 \arguments{
-\item{vx}{the X coefficients}
+\item{vx}{the X coefficients. Must have the same number of columns as \code{vy}.}
 
-\item{vy}{the Y coefficients}
+\item{vy}{the Y coefficients. Must have the same number of columns as \code{vx}.}
 
 \item{preproc_x}{the X pre-processor}
 


### PR DESCRIPTION
## Summary
- enforce that both blocks have equal columns in `cross_projector`
- document the column requirement in help page

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*