### PR TITLE
Validate colind in reprocess.cross_projector

### DIFF
--- a/R/twoway_projector.R
+++ b/R/twoway_projector.R
@@ -98,6 +98,8 @@ coef.cross_projector <- function(object, source=c("X", "Y"),...) {
 #' @inheritParams reprocess
 #' @param source the source of the data (X or Y block)
 #' @return the re(pre-)processed data
+#' @details When `colind` is provided, each index is validated to be within the
+#'   available coefficient rows using `chk::chk_subset`.
 #' @export
 #' @family reprocess
 reprocess.cross_projector <- function(x, new_data, colind=NULL, source=c("X", "Y"), ...) {
@@ -106,7 +108,8 @@ reprocess.cross_projector <- function(x, new_data, colind=NULL, source=c("X", "Y
     chk::chk_equal(ncol(new_data), nrow(coef.cross_projector(x, source=source)))
     colind <- 1:ncol(new_data)
   } else {
-    chk::chk_equal(length(colind), ncol(new_data)) 
+    chk::chk_equal(length(colind), ncol(new_data))
+    chk::chk_subset(colind, 1:nrow(coef.cross_projector(x, source=source)))
   }
     
   if (source == "X") {

--- a/man/reprocess.cross_projector.Rd
+++ b/man/reprocess.cross_projector.Rd
@@ -23,4 +23,8 @@ the re(pre-)processed data
 \description{
 reprocess a cross_projector instance
 }
+\details{
+When \code{colind} is supplied, each index is validated to lie within the
+available coefficient rows using \code{chk::chk_subset}.
+}
 \concept{reprocess}

--- a/tests/testthat/test_cross_projector.R
+++ b/tests/testthat/test_cross_projector.R
@@ -106,3 +106,20 @@ test_that("transfer converts X‑>Y (and Y‑>X) with low reconstruction error",
   mse_yx <- mean((X_hat - dims$X)^2)
   expect_lt(mse_yx, 1e-4)
 })
+
+# =========================================================================
+# 4. -- reprocess() validates column indices --------------------------------
+# =========================================================================
+test_that("reprocess.cross_projector validates column indices", {
+
+  dims <- make_blocks()
+  preproc <- prep(pass())
+  Xp <- init_transform(preproc, dims$X)
+  cp   <- cross_projector(dims$Vx, dims$Vy, preproc_x = preproc, preproc_y = preproc)
+
+  # Valid subset works
+  expect_silent(reprocess(cp, dims$X[, 1:2], colind = c(1, 2), source = "X"))
+
+  # Invalid index should error
+  expect_error(reprocess(cp, dims$X[, 1:2], colind = c(1, 10), source = "X"))
+})


### PR DESCRIPTION
## Summary
- check column index validity in `reprocess.cross_projector`
- document new validation rules
- test that invalid column indices error

## Testing
- `devtools::document()` *(fails: `R` missing)*