### PR TITLE
Improve cross projector ridge transfer

### DIFF
--- a/man/transfer.cross_projector.Rd
+++ b/man/transfer.cross_projector.Rd
@@ -26,4 +26,7 @@ Transferred data matrix.
 Convert between data representations in a multiblock or cross-decomposition
 model by projecting the input \code{new_data} from the \code{from} domain/block
 onto a latent space and then reconstructing it in the \code{to} domain/block.
+If \code{opts$ls_rr} is \code{TRUE}, the projection step uses a
+ridge-regularized least squares solution with penalty \code{opts$lambda} before
+any component subsetting occurs.
 }


### PR DESCRIPTION
## Summary
- apply ridge-regularized projection in `transfer.cross_projector()` when requested
- document new ridge behaviour for cross transfer
- test ridge branch of transfer

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*