### PR TITLE
Preserve array shape in bootstrap PCA

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -267,8 +267,8 @@ bootstrap_pca <- function(x, nboot = 100, k = NULL,
 
 
   # --- Aggregate Results ---
-  Ab_array <- simplify2array(lapply(res_list, `[[`, "Ab"))       # k x k x nboot_actual
-  Scores_array <- simplify2array(lapply(res_list, `[[`, "Scores")) # n x k x nboot_actual
+  Ab_array <- simplify2array(lapply(res_list, `[[`, "Ab"), higher = TRUE)       # k x k x nboot_actual
+  Scores_array <- simplify2array(lapply(res_list, `[[`, "Scores"), higher = TRUE) # n x k x nboot_actual
 
   # --- Calculate Bootstrap Moments and Z-scores ---
 


### PR DESCRIPTION
## Summary
- ensure Ab_array and Scores_array stay 3D arrays when only a single bootstrap sample is successful

## Testing
- `make test` *(fails: `No rule to make target 'test'`)*
- `R --version` *(fails: `R: command not found`)*