### PR TITLE
Add nboot input validation

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -9,7 +9,8 @@
 #' @param x An object of class 'pca' as returned by the provided `pca` function.
 #'   It's expected to contain loadings (`v`), scores (`s`), singular values (`sdev`),
 #'   left singular vectors (`u`), and pre-processing info (`preproc`).
-#' @param nboot The number of bootstrap resamples to perform (default: 100).
+#' @param nboot The number of bootstrap resamples to perform. Must be a positive
+#'   integer (default: 100).
 #' @param k The number of principal components to bootstrap (default: all
 #'   components available in the fitted PCA model `x`). Must be less than or
 #'   equal to the number of components in `x`.
@@ -159,6 +160,8 @@ bootstrap_pca <- function(x, nboot = 100, k = NULL,
       warning("Requested k (", k, ") exceeds the number of observations (", n, "). Results might be unstable.")
   }
   if (k <= 0 || !is.numeric(k) || k != round(k)) stop("k must be a positive integer.")
+  if (!is.numeric(nboot) || length(nboot) != 1 || nboot <= 0 || nboot != round(nboot))
+    stop("nboot must be a positive integer.")
 
   # Seed handling with future_lapply requires specific argument
   # if (!is.null(seed)) withr::local_seed(seed) # Apply seed locally before loop if not parallel

--- a/man/bootstrap_pca.Rd
+++ b/man/bootstrap_pca.Rd
@@ -20,7 +20,7 @@ bootstrap_pca(
 It's expected to contain loadings (\code{v}), scores (\code{s}), singular values (\code{sdev}),
 left singular vectors (\code{u}), and pre-processing info (\code{preproc}).}
 
-\item{nboot}{The number of bootstrap resamples to perform (default: 100).}
+\item{nboot}{The number of bootstrap resamples to perform. Must be a positive integer (default: 100).}
 
 \item{k}{The number of principal components to bootstrap (default: all
 components available in the fitted PCA model \code{x}). Must be less than or

--- a/tests/testthat/test_bootstrap.R
+++ b/tests/testthat/test_bootstrap.R
@@ -68,3 +68,11 @@ test_that("bootstrap means track dominant component and SD hierarchy is sensible
   # dominant component should be estimated more precisely
   expect_true(median(boot_res$sd_Vb[, 1]) < median(boot_res$sd_Vb[, 2]))
 })
+
+# -------------  4. input validation -----------------------------------------
+test_that("nboot must be a positive integer", {
+  expect_error(bootstrap_pca(toy_pca, nboot = 0, k = k),
+               "nboot must be a positive integer")
+  expect_error(bootstrap_pca(toy_pca, nboot = 2.5, k = k),
+               "nboot must be a positive integer")
+})


### PR DESCRIPTION
## Summary
- check that `nboot` is a positive integer at the start of `bootstrap_pca`
- document `nboot` requirement in roxygen and Rd file
- test that invalid `nboot` values throw an error

## Testing
- `R -q -e "devtools::test()"` *(fails: `bash: R: command not found`)*