### PR TITLE
Fix factor level ordering in discriminant_projector

### DIFF
--- a/R/discriminant_projector.R
+++ b/R/discriminant_projector.R
@@ -36,9 +36,10 @@ discriminant_projector <- function(v, s, sdev, preproc=prep(pass()), labels, cla
   chk::chk_equal(ncol(v), length(sdev))
   chk::chk_equal(length(labels), nrow(s))
   
-  # Ensure labels are factor and get named counts
-  labels <- factor(labels)
-  counts <- table(labels, dnn = NULL) 
+  # Ensure labels are factor; preserve level order if already factor
+  labels <- if (is.factor(labels)) factor(labels, levels = levels(labels))
+            else factor(labels)
+  counts <- table(labels, dnn = NULL)
   
   out <- bi_projector(v, s=s, sdev=sdev, preproc=preproc, labels=labels, 
                       counts=counts, classes=c(classes, "discriminant_projector"), ...)

--- a/tests/testthat/test_discriminant_projector.R
+++ b/tests/testthat/test_discriminant_projector.R
@@ -51,6 +51,24 @@ test_that("discriminant_projector constructor stores consistent state", {
   expect_equal(dim(dp$s), c(length(Y_signal), dim(dp$v)[2]))
 })
 
+test_that("discriminant_projector preserves factor level order", {
+
+  labs_custom <- factor(Y_signal, levels = c("B", "A"))
+  lda_fit  <- lda(X_signal, grouping = labs_custom)
+  preproc <- prep(pass())
+  Xp <- init_transform(preproc, X_signal)
+
+  dp <- discriminant_projector(
+          v      = lda_fit$scaling,
+          s      = X_signal %*% lda_fit$scaling,
+          sdev   = lda_fit$svd,
+          preproc = preproc,
+          labels = labs_custom,
+          Sigma  = lda_fit$covariance)
+
+  expect_equal(levels(dp$labels), levels(labs_custom))
+})
+
 # -------------------------------------------------------------------------
 # 2. Prediction engine (LDA & Euclidean) -----------------------------------
 # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep factor level order intact in `discriminant_projector`
- test that constructor preserves factor level ordering

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*