### PR TITLE
Handle singular covariance with pseudo inverse

### DIFF
--- a/R/discriminant_projector.R
+++ b/R/discriminant_projector.R
@@ -77,9 +77,10 @@ discriminant_projector <- function(v, s, sdev, preproc=prep(pass()), labels, cla
 #'
 #' This produces class predictions or posterior-like scores for new data, based on:
 #' \itemize{
-#'   \item \strong{LDA approach} (\code{method="lda"}), which uses a linear discriminant 
-#'         formula with a pooled covariance matrix if \code{x\$Sigma} is given, or 
-#'         the identity matrix if \code{Sigma=NULL}.
+#'   \item \strong{LDA approach} (\code{method="lda"}), which uses a linear discriminant
+#'         formula with a pooled covariance matrix if \code{x\$Sigma} is given, or
+#'         the identity matrix if \code{Sigma=NULL}. If that covariance matrix is
+#'         not invertible, a pseudo-inverse is used and a warning is emitted.
 #'   \item \strong{Euclid approach} (\code{method="euclid"}), which uses plain
 #'         Euclidean distance to each class mean in the subspace.
 #' }
@@ -159,7 +160,13 @@ predict.discriminant_projector <- function(object,
       # fallback to identity
       sigma_pooled <- diag(ncol(object$s))
     }
-    inv_sigma <- solve(sigma_pooled)
+    inv_sigma <- tryCatch(
+      solve(sigma_pooled),
+      error = function(e) {
+        warning("Covariance matrix not invertible; using pseudo-inverse via MASS::ginv")
+        MASS::ginv(sigma_pooled)
+      }
+    )
     
     # Precompute (for linear discriminants):
     means_inv  <- class_means %*% inv_sigma

--- a/man/predict.discriminant_projector.Rd
+++ b/man/predict.discriminant_projector.Rd
@@ -39,7 +39,8 @@ This produces class predictions or posterior-like scores for new data, based on:
 \itemize{
 \item \strong{LDA approach} (\code{method="lda"}), which uses a linear discriminant
 formula with a pooled covariance matrix if \code{x\$Sigma} is given, or
-the identity matrix if \code{Sigma=NULL}.
+the identity matrix if \code{Sigma=NULL}. If that covariance matrix is not
+invertible, a pseudo-inverse is used and a warning is emitted.
 \item \strong{Euclid approach} (\code{method="euclid"}), which uses plain
 Euclidean distance to each class mean in the subspace.
 }

--- a/tests/testthat/test_discriminant_projector.R
+++ b/tests/testthat/test_discriminant_projector.R
@@ -121,3 +121,34 @@ test_that("perm_test.discriminant_projector yields small p for signal and large 
   pt_noise <- perm_test(dp_noise, X_noise, nperm = 150)
   expect_true(pt_noise$p.value > 0.10)           # no real separation
 })
+
+# -------------------------------------------------------------------------
+# 4. Rank deficient covariance is handled via pseudo-inverse ---------------
+# -------------------------------------------------------------------------
+test_that("predict works when covariance is rank deficient", {
+
+  set.seed(123)
+  # create perfectly collinear feature to ensure singular covariance
+  X_rd <- matrix(rnorm(50 * 2), 50, 2)
+  X_rd <- cbind(X_rd, X_rd[,1])
+  Y_rd <- factor(rep(c("A", "B"), each = 25))
+
+  lda_fit <- lda(X_rd, grouping = Y_rd)
+
+  # manually supply rank deficient Sigma
+  Sigma_rd <- cov(X_rd)
+
+  preproc <- prep(pass())
+  init_transform(preproc, X_rd)
+
+  dp <- discriminant_projector(v      = lda_fit$scaling,
+                               s      = X_rd %*% lda_fit$scaling,
+                               sdev   = lda_fit$svd,
+                               preproc = preproc,
+                               labels = Y_rd,
+                               Sigma  = Sigma_rd)
+
+  preds <- predict(dp, X_rd, method = "lda", type = "class")
+  expect_length(preds, length(Y_rd))
+  expect_true(all(levels(preds) == levels(Y_rd)))
+})


### PR DESCRIPTION
## Summary
- fallback to using `ginv` if covariance inversion fails
- document pseudo-inverse behaviour in `predict.discriminant_projector`
- test prediction with a rank deficient covariance matrix

## Testing
- `R CMD build .` *(fails: `R: command not found`)*
- `R -q -e "devtools::test()"` *(fails: `R: command not found`)*