### PR TITLE
Fix intercept column removal for glmnet regressions

### DIFF
--- a/R/regress.R
+++ b/R/regress.R
@@ -117,12 +117,14 @@ regress <- function(X, Y, preproc=pass(), method=c("lm", "enet", "mridge", "pls"
       t(cf)
     }
     
-    # FIX: Remove intercept column from glmnet betas if intercept was FALSE for regress() input
-    if (method %in% c("mridge", "enet") && !intercept) {
-      b[, -1, drop=FALSE] # Remove the first column (intercept)
-    } else {
-      b
+    # FIX: Remove intercept column from glmnet betas to avoid dimension issues
+    # glmnet always includes an "(Intercept)" coefficient as the first column
+    # of the returned matrix, even when we supply our own intercept column.
+    # Drop that column unconditionally for the mridge and enet methods.
+    if (method %in% c("mridge", "enet")) {
+      b <- b[, -1, drop = FALSE]
     }
+    b
   }
   
   # Create a bi_projector

--- a/tests/testthat/test_regress.R
+++ b/tests/testthat/test_regress.R
@@ -47,3 +47,14 @@ test_that("can run a regress analysis with multiple y variables and enet", {
   expect_true(!is.null(reg))
   expect_true(!is.null(recon))
 })
+
+test_that("ridge and enet handle intercept correctly", {
+  mat1 <- matrix(rnorm(100*15), 100, 15)
+  y <- cbind(rnorm(100), rnorm(100))
+
+  r_ridge <- regress(mat1, y, preproc=pass(), method="mridge", intercept=TRUE)
+  r_enet  <- regress(mat1, y, preproc=pass(), method="enet", intercept=TRUE)
+
+  expect_equal(ncol(r_ridge$v), ncol(mat1) + 1)
+  expect_equal(ncol(r_enet$v), ncol(mat1) + 1)
+})


### PR DESCRIPTION
## Summary
- update `regress()` to always drop the glmnet `(Intercept)` column
- add regression tests covering intercept handling for `mridge` and `enet`

## Testing
- `Rscript -e "print('test')"` *(fails: command not found)*