### PR TITLE
Clean up geneig interface and output

### DIFF
--- a/R/geneig.R
+++ b/R/geneig.R
@@ -6,7 +6,6 @@
 #' @param A The left-hand side square matrix.
 #' @param B The right-hand side square matrix, same dimension as A.
 #' @param ncomp Number of eigenpairs to return.
-#' @param preproc A preprocessing function to apply to the matrices before solving the generalized eigenvalue problem.
 #' @param method One of:
 #'   - "robust": Uses a stable decomposition via a whitening transform (B must be symmetric PD).
 #'   - "sdiag":  Uses a spectral decomposition of B (must be symmetric PD). Requires A to be symmetric for meaningful results.
@@ -49,7 +48,6 @@
 geneig <- function(A = NULL,
                    B = NULL,
                    ncomp = 2,
-                   preproc = prep(pass()),
                    method = c("robust", "sdiag", "geigen", "primme"),
                    which = "LR", ...) {
   method <- match.arg(method)
@@ -198,16 +196,17 @@ geneig <- function(A = NULL,
   
   sdev <- sqrt(abs(ev)) # Use abs(Re(ev))
   
-  # Return a simple list with a class attribute
-  out <- list(
-    values  = ev,
-    vectors = vec,
-    sdev    = sdev,
-    ncomp   = ncomp,
-    method  = method
+  # Wrap results in a `projector` object
+  out <- projector(
+    v = vec,
+    preproc = prep(pass()),
+    values = ev,
+    sdev = sdev,
+    ncomp = ncomp,
+    method = method,
+    classes = "geneig"
   )
-  
-  class(out) <- c("geneig", "list")
+
   out
 }
 

--- a/man/geneig.Rd
+++ b/man/geneig.Rd
@@ -8,7 +8,6 @@ geneig(
   A = NULL,
   B = NULL,
   ncomp = 2,
-  preproc = prep(pass()),
   method = c("robust", "sdiag", "geigen", "primme"),
   which = "LR",
   ...
@@ -20,8 +19,6 @@ geneig(
 \item{B}{The right-hand side square matrix, same dimension as A.}
 
 \item{ncomp}{Number of eigenpairs to return.}
-
-\item{preproc}{A preprocessing function to apply to the matrices before solving the generalized eigenvalue problem.}
 
 \item{method}{One of:
 \itemize{

--- a/tests/testthat/test_geneig.R
+++ b/tests/testthat/test_geneig.R
@@ -7,8 +7,9 @@ B <- matrix(c(6, 2, 2, 5), nrow=2, byrow=TRUE)  # B must be symmetric and positi
 
 
 test_that("geigen method returns correct results", {
-  result <- geneig(A = A, B = B, ncomp=2, method="geigen")
-  expect_equal(dim(result$vectors), c(2, 2))
+  result <- geneig(A = A, B = B, ncomp = 2, method = "geigen")
+  expect_s3_class(result, c("geneig", "projector"))
+  expect_equal(dim(components(result)), c(2, 2))
   expect_equal(length(result$values), 2)
   # Eigenvalues can be complex for geigen, check real part if needed or just existence
   # expect_true(all(Re(result$values) > 0)) # This might not hold for general A
@@ -16,8 +17,9 @@ test_that("geigen method returns correct results", {
 
 test_that("robust method equivalent test using geigen", {
   # Changed method from "robust" to "geigen" as "robust" is removed
-  result <- geneig(A = A, B = B, ncomp=2, method="geigen")
-  expect_equal(dim(result$vectors), c(2, 2))
+  result <- geneig(A = A, B = B, ncomp = 2, method = "geigen")
+  expect_s3_class(result, c("geneig", "projector"))
+  expect_equal(dim(components(result)), c(2, 2))
   expect_equal(length(result$values), 2)
   # Cannot guarantee positive values for geigen
   # expect_true(all(result$values > 0))
@@ -25,8 +27,9 @@ test_that("robust method equivalent test using geigen", {
 
 test_that("sdiag method equivalent test using geigen", {
   # Changed method from "sdiag" to "geigen" as "sdiag" is removed
-  result <- geneig(A = A, B = B, ncomp=2, method="geigen")
-  expect_equal(dim(result$vectors), c(2, 2))
+  result <- geneig(A = A, B = B, ncomp = 2, method = "geigen")
+  expect_s3_class(result, c("geneig", "projector"))
+  expect_equal(dim(components(result)), c(2, 2))
   expect_equal(length(result$values), 2)
   # Cannot guarantee positive values for geigen
   # expect_true(all(result$values > 0))
@@ -34,8 +37,9 @@ test_that("sdiag method equivalent test using geigen", {
 
 test_that("primme method returns correct results", {
   skip_if_not_installed("PRIMME")  # Skip if PRIMME is not available
-  result <- geneig(A = A, B = B, ncomp=2, method="primme", which="LA")
-  expect_equal(dim(result$vectors), c(2, 2))
+  result <- geneig(A = A, B = B, ncomp = 2, method = "primme", which = "LA")
+  expect_s3_class(result, c("geneig", "projector"))
+  expect_equal(dim(components(result)), c(2, 2))
   expect_equal(length(result$values), 2)
   expect_true(all(result$values > 0))
 })
@@ -48,10 +52,11 @@ test_that("non-square matrices are handled", {
 })
 
 test_that("negative and very small eigenvalues in B are handled in geigen", {
-  B_with_negative <- matrix(c(4, 1, 1, -2), nrow=2, byrow=TRUE)
+  B_with_negative <- matrix(c(4, 1, 1, -2), nrow = 2, byrow = TRUE)
   # Changed method from "sdiag" to "geigen"
-  result <- geneig(A = A, B = B_with_negative, ncomp=2, method="geigen")
-  expect_equal(dim(result$vectors), c(2, 2))
+  result <- geneig(A = A, B = B_with_negative, ncomp = 2, method = "geigen")
+  expect_s3_class(result, c("geneig", "projector"))
+  expect_equal(dim(components(result)), c(2, 2))
   # Cannot guarantee positive values for geigen
   # expect_true(all(result$values > 0))
 })


### PR DESCRIPTION
## Summary
- remove unused `preproc` argument from `geneig`
- return a `projector` object from `geneig`
- update docs accordingly
- adjust tests for new return structure

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*